### PR TITLE
user GetLocaleInfo to map lcid to locale name below Windows Vista

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: go
+go:
+  - 1.2
+before_install:
+- go get github.com/onsi/ginkgo/...
+- go get github.com/onsi/gomega/...
+- go install github.com/onsi/ginkgo/ginkgo
+script: PATH=$PATH:$HOME/gopath/bin ginkgo -r .
+branches:
+  only:
+  - master

--- a/README.md
+++ b/README.md
@@ -1,0 +1,44 @@
+# Jibber Jabber [![Build Status](https://travis-ci.org/pivotal-cf-experimental/jibber_jabber.svg?branch=master)](https://travis-ci.org/pivotal-cf-experimental/jibber_jabber)
+Jibber Jabber is a GoLang Library that can be used to detect an operating system's current language.
+
+### OS Support
+
+OSX and Linux via the `LC_ALL` and `LANG` environment variables. These are standard variables that are used in ALL versions of UNIX for language detection.
+
+Windows via [GetUserDefaultLocaleName](http://msdn.microsoft.com/en-us/library/windows/desktop/dd318136.aspx) and [GetSystemDefaultLocaleName](http://msdn.microsoft.com/en-us/library/windows/desktop/dd318122.aspx) system calls. These calls are supported in Windows Vista and up.
+
+# Usage
+Add the following line to your go `import`:
+
+```
+	"github.com/pivotal-cf-experimental/jibber_jabber"
+```
+
+### DetectIETF
+`DetectIETF` will return the current locale as a string. The format of the locale will be the [ISO 639](http://en.wikipedia.org/wiki/ISO_639) two-letter language code, a DASH, then an [ISO 3166](http://en.wikipedia.org/wiki/ISO_3166-1) two-letter country code.
+
+```
+	userLocale, err := jibber_jabber.DetectIETF()
+	println("Locale:", userLocale)
+```
+
+### DetectLanguage
+`DetectLanguage` will return the current languge as a string. The format will be the [ISO 639](http://en.wikipedia.org/wiki/ISO_639) two-letter language code.
+
+```
+	userLanguage, err := jibber_jabber.DetectLanguage()
+	println("Language:", userLanguage)
+```
+
+### DetectTerritory
+`DetectTerritory` will return the current locale territory as a string. The format will be the [ISO 3166](http://en.wikipedia.org/wiki/ISO_3166-1) two-letter country code.
+
+```
+	localeTerritory, err := jibber_jabber.DetectTerritory()
+	println("Territory:", localeTerritory)
+```
+
+### Errors
+All the Detect commands will return an error if they are unable to read the Locale from the system.
+
+For Windows, additional error information is provided due to the nature of the system call being used.

--- a/ci/scripts/windows-64-test.bat
+++ b/ci/scripts/windows-64-test.bat
@@ -1,0 +1,5 @@
+git fetch
+git checkout %GIT_COMMIT%
+
+SET GOPATH=%CD%\Godeps\_workspace;c:\Users\Administrator\go
+c:\Go\bin\go test -v .

--- a/jibber_jabber.go
+++ b/jibber_jabber.go
@@ -1,0 +1,22 @@
+package jibber_jabber
+
+import (
+	"strings"
+)
+
+const (
+	COULD_NOT_DETECT_PACKAGE_ERROR_MESSAGE = "Could not detect Language"
+)
+
+func splitLocale(locale string) (string, string) {
+	formattedLocale := strings.Split(locale, ".")[0]
+	formattedLocale = strings.Replace(formattedLocale, "-", "_", -1)
+
+	pieces := strings.Split(formattedLocale, "_")
+	language := pieces[0]
+	territory := ""
+	if len(pieces) > 1 {
+		territory = strings.Split(formattedLocale, "_")[1]
+	}
+	return language, territory
+}

--- a/jibber_jabber_suite_test.go
+++ b/jibber_jabber_suite_test.go
@@ -1,0 +1,13 @@
+package jibber_jabber_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestJibberJabber(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Jibber Jabber Suite")
+}

--- a/jibber_jabber_unix.go
+++ b/jibber_jabber_unix.go
@@ -1,0 +1,57 @@
+// +build darwin freebsd linux netbsd openbsd
+
+package jibber_jabber
+
+import (
+	"errors"
+	"os"
+	"strings"
+)
+
+func getLangFromEnv() (locale string) {
+	locale = os.Getenv("LC_ALL")
+	if locale == "" {
+		locale = os.Getenv("LANG")
+	}
+	return
+}
+
+func getUnixLocale() (unix_locale string, err error) {
+	unix_locale = getLangFromEnv()
+	if unix_locale == "" {
+		err = errors.New(COULD_NOT_DETECT_PACKAGE_ERROR_MESSAGE)
+	}
+
+	return
+}
+
+func DetectIETF() (locale string, err error) {
+	unix_locale, err := getUnixLocale()
+	if err == nil {
+		language, territory := splitLocale(unix_locale)
+		locale = language
+		if territory != "" {
+			locale = strings.Join([]string{language, territory}, "-")
+		}
+	}
+
+	return
+}
+
+func DetectLanguage() (language string, err error) {
+	unix_locale, err := getUnixLocale()
+	if err == nil {
+		language, _ = splitLocale(unix_locale)
+	}
+
+	return
+}
+
+func DetectTerritory() (territory string, err error) {
+	unix_locale, err := getUnixLocale()
+	if err == nil {
+		_, territory = splitLocale(unix_locale)
+	}
+
+	return
+}

--- a/jibber_jabber_unix_test.go
+++ b/jibber_jabber_unix_test.go
@@ -1,0 +1,128 @@
+// +build darwin freebsd linux netbsd openbsd
+
+package jibber_jabber_test
+
+import (
+	"fmt"
+	. "github.com/pivotal-cf-experimental/jibber_jabber"
+	"os"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Unix", func() {
+	AfterEach(func() {
+		if err := os.Setenv("LC_ALL", ""); err != nil {
+			fmt.Errorf("Unable to set environment variable: %v", err)
+		}
+		if err := os.Setenv("LANG", "en_US.UTF-8"); err != nil {
+			fmt.Errorf("Unable to set environment variable: %v", err)
+		}
+	})
+
+	Describe("#DetectIETF", func() {
+		Context("Returns IETF encoded locale", func() {
+			It("should return the locale set to LC_ALL", func() {
+				if err := os.Setenv("LC_ALL", "fr_FR.UTF-8"); err != nil {
+					fmt.Errorf("Unable to set environment variable: %v", err)
+				}
+				result, _ := DetectIETF()
+				Ω(result).Should(Equal("fr-FR"))
+			})
+
+			It("should return the locale set to LANG if LC_ALL isn't set", func() {
+				if err := os.Setenv("LANG", "fr_FR.UTF-8"); err != nil {
+					fmt.Errorf("Unable to set environment variable: %v", err)
+				}
+
+				result, _ := DetectIETF()
+				Ω(result).Should(Equal("fr-FR"))
+			})
+
+			It("should return an error if it cannot detect a locale", func() {
+				if err := os.Setenv("LANG", ""); err != nil {
+					fmt.Errorf("Unable to set environment variable: %v", err)
+				}
+
+				_, err := DetectIETF()
+				Ω(err.Error()).Should(Equal(COULD_NOT_DETECT_PACKAGE_ERROR_MESSAGE))
+			})
+		})
+
+		Context("when the locale is simply 'fr'", func() {
+			BeforeEach(func() {
+				if err := os.Setenv("LANG", "fr"); err != nil {
+					fmt.Errorf("Unable to set environment variable: %v", err)
+				}
+			})
+
+			It("should return the locale without a territory", func() {
+				language, err := DetectIETF()
+				Ω(err).ShouldNot(HaveOccurred())
+				Ω(language).Should(Equal("fr"))
+			})
+		})
+	})
+
+	Describe("#DetectLanguage", func() {
+		Context("Returns encoded language", func() {
+			It("should return the language set to LC_ALL", func() {
+				if err := os.Setenv("LC_ALL", "fr_FR.UTF-8"); err != nil {
+					fmt.Errorf("Unable to set environment variable: %v", err)
+				}
+				result, _ := DetectLanguage()
+				Ω(result).Should(Equal("fr"))
+			})
+
+			It("should return the language set to LANG if LC_ALL isn't set", func() {
+				if err := os.Setenv("LANG", "fr_FR.UTF-8"); err != nil {
+					fmt.Errorf("Unable to set environment variable: %v", err)
+				}
+
+				result, _ := DetectLanguage()
+				Ω(result).Should(Equal("fr"))
+			})
+
+			It("should return an error if it cannot detect a language", func() {
+				if err := os.Setenv("LANG", ""); err != nil {
+					fmt.Errorf("Unable to set environment variable: %v", err)
+				}
+
+				_, err := DetectLanguage()
+				Ω(err.Error()).Should(Equal(COULD_NOT_DETECT_PACKAGE_ERROR_MESSAGE))
+			})
+		})
+	})
+
+	Describe("#DetectTerritory", func() {
+		Context("Returns encoded territory", func() {
+			It("should return the territory set to LC_ALL", func() {
+				if err := os.Setenv("LC_ALL", "fr_FR.UTF-8"); err != nil {
+					fmt.Errorf("Unable to set environment variable: %v", err)
+				}
+				result, _ := DetectTerritory()
+				Ω(result).Should(Equal("FR"))
+			})
+
+			It("should return the territory set to LANG if LC_ALL isn't set", func() {
+				if err := os.Setenv("LANG", "fr_FR.UTF-8"); err != nil {
+					fmt.Errorf("Unable to set environment variable: %v", err)
+				}
+
+				result, _ := DetectTerritory()
+				Ω(result).Should(Equal("FR"))
+			})
+
+			It("should return an error if it cannot detect a territory", func() {
+				if err := os.Setenv("LANG", ""); err != nil {
+					fmt.Errorf("Unable to set environment variable: %v", err)
+				}
+
+				_, err := DetectTerritory()
+				Ω(err.Error()).Should(Equal(COULD_NOT_DETECT_PACKAGE_ERROR_MESSAGE))
+			})
+		})
+	})
+
+})

--- a/jibber_jabber_windows.go
+++ b/jibber_jabber_windows.go
@@ -1,0 +1,119 @@
+// +build windows
+
+package jibber_jabber
+
+import (
+	"errors"
+	"syscall"
+	"unsafe"
+)
+
+const LOCALE_NAME_MAX_LENGTH uint32 = 85
+// https://msdn.microsoft.com/en-us/library/windows/desktop/dd373848(v=vs.85).aspx
+const LOCALE_SISO_NAME_MAX_LENGTH uint32 = 9
+// defined in winnls.h
+const LOCALE_SISO639LANGNAME uint32 = 0x59
+const LOCALE_SISO3166CTRYNAME uint32 = 0x5a
+
+func getWindowsLocaleFrom(sysCall string) (locale string, err error) {
+	buffer := make([]uint16, LOCALE_NAME_MAX_LENGTH)
+
+	dll := syscall.MustLoadDLL("kernel32")
+	proc := dll.MustFindProc(sysCall)
+	r, _, dllError := proc.Call(uintptr(unsafe.Pointer(&buffer[0])), uintptr(LOCALE_NAME_MAX_LENGTH))
+	if r == 0 {
+		err = errors.New(COULD_NOT_DETECT_PACKAGE_ERROR_MESSAGE + ":\n" + dllError.Error())
+		return
+	}
+
+	locale = syscall.UTF16ToString(buffer)
+
+	return
+}
+
+func getAllWindowsLocaleFrom(sysCall string) (string, error) {
+	dll, err := syscall.LoadDLL("kernel32")
+	if err != nil {
+		return "", errors.New("Could not find kernel32 dll")
+	}
+
+	proc, err := dll.FindProc(sysCall)
+	if err != nil {
+		return "", err
+	}
+
+	locale, _, dllError := proc.Call()
+	if locale == 0 {
+		return "", errors.New(COULD_NOT_DETECT_PACKAGE_ERROR_MESSAGE + ":\n" + dllError.Error())
+	}
+	proc, err = dll.FindProc("GetLocaleInfoW")
+	if err != nil {
+		return "", err
+	}
+	langBuf := make([]uint16, LOCALE_SISO_NAME_MAX_LENGTH)
+	r, _, dllError := proc.Call(locale, uintptr(LOCALE_SISO639LANGNAME), uintptr(unsafe.Pointer(&langBuf[0])), uintptr(LOCALE_SISO_NAME_MAX_LENGTH))
+	if r == 0 {
+		err = errors.New(COULD_NOT_DETECT_PACKAGE_ERROR_MESSAGE + ":\n" + dllError.Error())
+		return "", err
+	}
+	countryBuf := make([]uint16, LOCALE_SISO_NAME_MAX_LENGTH)
+	r, _, dllError = proc.Call(locale, uintptr(LOCALE_SISO3166CTRYNAME), uintptr(unsafe.Pointer(&countryBuf[0])), uintptr(LOCALE_SISO_NAME_MAX_LENGTH))
+	if r == 0 {
+		err = errors.New(COULD_NOT_DETECT_PACKAGE_ERROR_MESSAGE + ":\n" + dllError.Error())
+		return "", err
+	}
+	return syscall.UTF16ToString(langBuf) + "-" + syscall.UTF16ToString(countryBuf), nil
+}
+
+func getWindowsLocale() (locale string, err error) {
+	dll, err := syscall.LoadDLL("kernel32")
+	if err != nil {
+		return "", errors.New("Could not find kernel32 dll")
+	}
+
+	proc, err := dll.FindProc("GetVersion")
+	if err != nil {
+		return "", err
+	}
+
+	v, _, _ := proc.Call()
+	windowsVersion := byte(v)
+	isVistaOrGreater := (windowsVersion >= 6)
+
+	if isVistaOrGreater {
+		locale, err = getWindowsLocaleFrom("GetUserDefaultLocaleName")
+		if err != nil {
+			locale, err = getWindowsLocaleFrom("GetSystemDefaultLocaleName")
+		}
+	} else if !isVistaOrGreater {
+		locale, err = getAllWindowsLocaleFrom("GetUserDefaultLCID")
+		if err != nil {
+			locale, err = getAllWindowsLocaleFrom("GetSystemDefaultLCID")
+		}
+	} else {
+		panic(v)
+	}
+	return
+}
+func DetectIETF() (locale string, err error) {
+	locale, err = getWindowsLocale()
+	return
+}
+
+func DetectLanguage() (language string, err error) {
+	windows_locale, err := getWindowsLocale()
+	if err == nil {
+		language, _ = splitLocale(windows_locale)
+	}
+
+	return
+}
+
+func DetectTerritory() (territory string, err error) {
+	windows_locale, err := getWindowsLocale()
+	if err == nil {
+		_, territory = splitLocale(windows_locale)
+	}
+
+	return
+}

--- a/jibber_jabber_windows_test.go
+++ b/jibber_jabber_windows_test.go
@@ -1,0 +1,50 @@
+// +build windows
+
+package jibber_jabber_test
+
+import (
+	. "github.com/pivotal-cf-experimental/jibber_jabber"
+	"regexp"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+const (
+	LOCALE_REGEXP    = "^[a-z]{2}-[A-Z]{2}$"
+	LANGUAGE_REGEXP  = "^[a-z]{2}$"
+	TERRITORY_REGEXP = "^[A-Z]{2}$"
+)
+
+var _ = Describe("Windows", func() {
+	BeforeEach(func() {
+		locale, err := DetectIETF()
+		Ω(err).Should(BeNil())
+		Ω(locale).ShouldNot(BeNil())
+		Ω(locale).ShouldNot(Equal(""))
+	})
+
+	Describe("#DetectIETF", func() {
+		It("detects correct IETF locale", func() {
+			locale, _ := DetectIETF()
+			matched, _ := regexp.MatchString(LOCALE_REGEXP, locale)
+			Ω(matched).Should(BeTrue())
+		})
+	})
+
+	Describe("#DetectLanguage", func() {
+		It("detects correct Language", func() {
+			language, _ := DetectLanguage()
+			matched, _ := regexp.MatchString(LANGUAGE_REGEXP, language)
+			Ω(matched).Should(BeTrue())
+		})
+	})
+
+	Describe("#DetectTerritory", func() {
+		It("detects correct Territory", func() {
+			territory, _ := DetectTerritory()
+			matched, _ := regexp.MatchString(TERRITORY_REGEXP, territory)
+			Ω(matched).Should(BeTrue())
+		})
+	})
+})


### PR DESCRIPTION
As we can get from system,  there's no need to maintain SUPPORTED_LOCALES map. As per [the doc](https://msdn.microsoft.com/en-us/library/windows/desktop/dd318101%28v=vs.85%29.aspx), `GetLocaleInfo` works since Windows 2000.

I don't have XP box, but modified `isVistaOrGreater` to false, and tested on Windows 8.1 VM. Works well on 'en-US' and 'zh-CN' locale.
